### PR TITLE
Re-key the CI cache on Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
           path: |
             target
             /usr/share/rust/.cargo
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -67,9 +67,9 @@ jobs:
           path: |
             target
             /usr/share/rust/.cargo
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.toml') }}
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
@@ -88,9 +88,9 @@ jobs:
           path: |
             target
             /usr/share/rust/.cargo
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.toml') }}
       - name: Run cargo doc
         uses: actions-rs/cargo@v1
         with:
@@ -128,9 +128,9 @@ jobs:
           path: |
             target
             /usr/share/rust/.cargo
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
Since this is a library, we don't currently check in the Cargo.lock which makes it a poor cache key.

Cargo.toml seems like a reasonable stand-in.