### PR TITLE
Replace an impossible error with a debug assert

### DIFF
--- a/src/file_format.rs
+++ b/src/file_format.rs
@@ -271,9 +271,10 @@ where
             }
 
             let terminator: u8 = self.bitstream.get_integer(1)?;
-            if terminator != 0 {
-                return Err(DecodeError::InvalidTree);
-            }
+            debug_assert!(
+                terminator == 0,
+                "We know that the next bit wasn't 1 because the while loop above terminated"
+            );
 
             bit_lengths.push(initial_bit_length);
         }


### PR DESCRIPTION
We had a while loop that terminated once the next bit wasn't a 1, but then we checked that the same bit was a 0 and returned an error if it wasn't. But that should be impossible, so I replaced that check with a debug_assert. We do need to still read the next bit to move the bitstream pointer, of course.